### PR TITLE
Handle instrumentation exceptions

### DIFF
--- a/lib/rails/active_record/tracer.rb
+++ b/lib/rails/active_record/tracer.rb
@@ -20,6 +20,8 @@ module ActiveRecord
                           cached: payload.fetch(:cached, false),
                           connection_id: payload.fetch(:connection_id))
 
+        Rails::Tracer::SpanHelpers.set_error(span, payload[:exception_object]) if payload[:exception]
+
         span.finish(end_time: finish)
       end
 

--- a/lib/rails/active_support/cache/tracer.rb
+++ b/lib/rails/active_support/cache/tracer.rb
@@ -45,6 +45,9 @@ module ActiveSupport
                             start_time: start,
                             **payload)
 
+
+          Rails::Tracer::SpanHelpers.set_error(span, payload[:exception_object]) if payload[:exception]
+
           span.finish(end_time: finish)
         end
 

--- a/lib/rails/span_helpers.rb
+++ b/lib/rails/span_helpers.rb
@@ -1,0 +1,12 @@
+module Rails
+  module Tracer
+    module SpanHelpers
+      class << self
+        def set_error(span, exception)
+          span.set_tag('error', true)
+          span.log(event: 'error', :'error.object' => exception)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails/tracer.rb
+++ b/lib/rails/tracer.rb
@@ -1,3 +1,4 @@
+require "rails/span_helpers"
 require "rails/rack/tracer"
 require "rails/active_record/tracer"
 require "rails/active_support/cache/tracer"

--- a/spec/rails/active_suppport/cache/tracer_spec.rb
+++ b/spec/rails/active_suppport/cache/tracer_spec.rb
@@ -77,6 +77,16 @@ RSpec.describe ActiveSupport::Cache::Tracer do
         expect(tracer).to have_span.with_tag('cache.hit', false)
       end
     end
+
+    context "exception thrown during cache operation" do
+      it "sets error on span" do
+        exception = Timeout::Error.new
+        expect { Rails.cache.fetch(test_key) { raise exception } }.to raise_error(exception)
+        expect(tracer).to have_span
+          .with_tag('error', true)
+          .with_log(event: 'error', :'error.object' => exception)
+      end
+    end
   end
 
   describe "dalli store auto-instrumentation option" do

--- a/spec/rails/span_helpers_spec.rb
+++ b/spec/rails/span_helpers_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe Rails::Tracer::SpanHelpers do
+  describe "Class Methods" do
+    it { should respond_to :set_error }
+  end
+
+  describe :set_error do
+    let(:tracer) { Test::Tracer.new }
+    let(:span) { tracer.start_span("failed span") }
+    let(:exception) { Exception.new("test exception") }
+
+    before do
+      Rails::Tracer::SpanHelpers.set_error(span, exception)
+    end
+
+    it 'marks the span as failed' do
+      expect(span).to have_tag('error', true)
+    end
+
+    it 'logs the error' do
+      expect(span).to have_log(event: 'error', :'error.object' => exception)
+    end
+
+  end
+end


### PR DESCRIPTION
As described in http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html 

> If an exception happens during that particular instrumentation the payload will have a key :exception with an array of two elements as value: a string with the name of the exception class, and the exception message. The :exception_object key of the payload will have the exception itself as the value.

The change handles propagated exceptions, and marks spans in a standard way as failed. 

Related to #21 