### PR TITLE
New opentracing 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ will enabled all of them (except for Rack/ActionDispatch instrumentation).
 ### Usage
 
 ```ruby
-require 'rails/tracer'
+require 'rack/tracer'
+Rails.configuration.middleware.insert_after(Rails::Rack::Logger, Rack::Tracer)
 
-Rails::Tracer.instrument
+require 'rails/tracer'
+Rails.configuration.middleware.insert_after(Rack::Tracer, Rails::Rack::Tracer)
+Rails::Tracer.instrument(active_span: -> { OpenTracing.global_tracer.active_span })
 ```
 
 ## ActionDispatch 

--- a/rails-tracer.gemspec
+++ b/rails-tracer.gemspec
@@ -22,9 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
-  spec.add_dependency "rack-tracer", "~> 0.3.0"
-  spec.add_dependency "method-tracer", "~> 1.1"
+  spec.add_dependency 'opentracing', '~> 0.4'
+  spec.add_dependency "rack-tracer", "~> 0.9.0"
 
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "puma", "~> 3.7"


### PR DESCRIPTION
This uses opentracing 0.4 and the latest rack-tracer and improves the readme to give an example where spans are automatically grouped by request.